### PR TITLE
Feat: Unify UI with a Centralized Neumorphic Theme

### DIFF
--- a/Frontend/src/components/ChatInterface.jsx
+++ b/Frontend/src/components/ChatInterface.jsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react';
 import axios from 'axios';
 
-const ChatInterface = ({ messages, setMessages }) => {
+const ChatInterface = ({ messages, setMessages, theme }) => {
+  const { darkMode, setDarkMode, neumorph, bgColor, cardColor, textColor, borderColor } = theme;
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef(null);
@@ -124,9 +125,9 @@ const ChatInterface = ({ messages, setMessages }) => {
   };
 
   return (
-    <div className="flex flex-col h-full bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden">
+    <div className={`flex flex-col h-full ${cardColor} shadow-lg rounded-lg overflow-hidden m-2`}>
       {/* Messages container */}
-      <div className="flex-1 p-4 overflow-y-auto bg-gray-50 dark:bg-gray-900">
+      <div className={`flex-1 p-4 overflow-y-auto ${bgColor}`}>
         <div className="space-y-4">
           {messages.map((message, index) => (
             <div
@@ -137,7 +138,7 @@ const ChatInterface = ({ messages, setMessages }) => {
                 className={`max-w-xs md:max-w-md lg:max-w-lg rounded-lg px-4 py-2 ${
                   message.role === 'user'
                     ? 'bg-blue-500 text-white rounded-br-none'
-                    : 'bg-gray-200 text-gray-800 rounded-bl-none dark:bg-gray-700 dark:text-gray-200'
+                    : `${cardColor} rounded-bl-none`
                 }`}
               >
                 {message.role === 'assistant' ? (
@@ -164,7 +165,7 @@ const ChatInterface = ({ messages, setMessages }) => {
       </div>
 
       {/* Input area */}
-      <div className="p-4 bg-white border-t dark:bg-gray-800 dark:border-gray-700">
+      <div className={`p-4 ${cardColor} border-t ${borderColor}`}>
         <form onSubmit={handleSubmit} className="flex items-start space-x-2">
           <textarea
             ref={inputRef}
@@ -172,7 +173,7 @@ const ChatInterface = ({ messages, setMessages }) => {
             onChange={(e) => setInputValue(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Ask me about your legal rights, relevant laws, or case precedents..."
-            className="flex-1 border border-gray-300 rounded-lg px-4 py-2 resize-none overflow-y-auto focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+            className={`flex-1 ${bgColor} ${borderColor} border rounded-lg px-4 py-2 resize-none overflow-y-auto focus:outline-none focus:ring-2 focus:ring-blue-500`}
             rows="1"
             style={{ maxHeight: '150px' }}
             disabled={isLoading}
@@ -180,7 +181,7 @@ const ChatInterface = ({ messages, setMessages }) => {
           <button
             type="submit"
             disabled={!inputValue.trim() || isLoading}
-            className="bg-blue-500 text-white rounded-full px-4 py-2 self-end hover:bg-blue-600 disabled:bg-blue-300 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className={`bg-blue-500 text-white rounded-full px-4 py-2 self-end hover:bg-blue-600 disabled:bg-blue-300 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-blue-500 hover:${neumorph}`}
           >
             Send
           </button>

--- a/Frontend/src/components/Sidebar.jsx
+++ b/Frontend/src/components/Sidebar.jsx
@@ -16,7 +16,8 @@ import {
   Moon,
 } from "lucide-react";
 
-const Sidebar = ({ darkMode, setDarkMode }) => {
+const Sidebar = ({ theme }) => {
+  const { darkMode, setDarkMode, neumorph, bgColor, cardColor, textColor, borderColor } = theme;
   const [collapsed, setCollapsed] = useState(false);
 
   const navItemsMain = [
@@ -33,15 +34,6 @@ const Sidebar = ({ darkMode, setDarkMode }) => {
     { label: "Billing", icon: Receipt },
     { label: "Notifications", icon: Bell },
   ];
-
-  const neumorph =
-    darkMode
-      ? "shadow-[inset_4px_4px_10px_#1a1a1a,inset_-4px_-4px_10px_#2c2c2c]"
-      : "shadow-[inset_4px_4px_10px_#d1d9e6,inset_-4px_-4px_10px_#ffffff]";
-
-  const bgColor = darkMode ? "bg-[#1e1e1e] text-white" : "bg-[#f1f3f6] text-gray-800";
-  const cardColor = darkMode ? "bg-[#252525]" : "bg-[#e2e8f0]";
-  const borderColor = darkMode ? "border-[#2c2c2c]" : "border-gray-300";
 
   return (
     <div

--- a/Frontend/src/components/Summary.jsx
+++ b/Frontend/src/components/Summary.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 
-const Summary = ({ messages }) => {
+const Summary = ({ messages, theme }) => {
+  const { darkMode, setDarkMode, neumorph, bgColor, cardColor, textColor, borderColor } = theme;
   const [summary, setSummary] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const BACKEND_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3001';
@@ -22,20 +23,20 @@ const Summary = ({ messages }) => {
   };
 
   return (
-    <div className="w-80 h-full bg-gray-50 dark:bg-gray-800 p-4 border-l border-gray-200 dark:border-gray-700 flex flex-col m-2 rounded-lg shadow-lg text-gray-900 dark:text-gray-100">
+    <div className={`w-80 h-full ${cardColor} p-4 border-l ${borderColor} flex flex-col m-2 rounded-lg shadow-lg`}>
       <h2 className="text-lg font-semibold mb-4">Conversation Summary</h2>
       <button
         onClick={handleSummarize}
         disabled={isLoading || messages.length <= 1}
-        className="bg-blue-500 text-white rounded-md px-4 py-2 mb-4 hover:bg-blue-600 disabled:bg-blue-300"
+        className={`bg-blue-500 text-white rounded-md px-4 py-2 mb-4 hover:bg-blue-600 disabled:bg-blue-300 hover:${neumorph}`}
       >
         {isLoading ? 'Summarizing...' : 'Summarize Conversation'}
       </button>
-      <div className="flex-1 overflow-y-auto border rounded-md p-2 bg-white dark:bg-gray-700">
+      <div className={`flex-1 overflow-y-auto border rounded-md p-2 ${bgColor} ${borderColor}`}>
         {summary ? (
           <p className="text-sm whitespace-pre-wrap">{summary}</p>
         ) : (
-          <p className="text-sm text-gray-500 dark:text-gray-400">Click the button to generate a summary of the current conversation.</p>
+          <p className="text-sm text-gray-500">Click the button to generate a summary of the current conversation.</p>
         )}
       </div>
     </div>

--- a/Frontend/src/pages/Home.jsx
+++ b/Frontend/src/pages/Home.jsx
@@ -17,13 +17,23 @@ const Home = () => {
     }
   }, [darkMode]);
 
+  const neumorph = darkMode
+    ? "shadow-[inset_4px_4px_10px_#1a1a1a,inset_-4px_-4px_10px_#2c2c2c]"
+    : "shadow-[inset_4px_4px_10px_#d1d9e6,inset_-4px_-4px_10px_#ffffff]";
+  const bgColor = darkMode ? "bg-[#1e1e1e]" : "bg-[#f1f3f6]";
+  const cardColor = darkMode ? "bg-[#252525]" : "bg-[#e2e8f0]";
+  const textColor = darkMode ? "text-white" : "text-gray-800";
+  const borderColor = darkMode ? "border-[#2c2c2c]" : "border-gray-300";
+
+  const theme = { darkMode, setDarkMode, neumorph, bgColor, cardColor, textColor, borderColor };
+
   return (
-    <div className="flex h-screen bg-gray-100 dark:bg-gray-900 overflow-hidden">
-      <Sidebar darkMode={darkMode} setDarkMode={setDarkMode} />
+    <div className={`flex h-screen w-full ${bgColor} ${textColor} overflow-hidden`}>
+      <Sidebar theme={theme} />
       <div className="flex-1 flex flex-col">
-        <ChatWindow messages={messages} setMessages={setMessages} />
+        <ChatWindow messages={messages} setMessages={setMessages} theme={theme} />
       </div>
-      <Summary messages={messages} />
+      <Summary messages={messages} theme={theme} />
     </div>
   );
 };


### PR DESCRIPTION
This commit refactors the entire frontend to use a single, centralized theme, ensuring a consistent look and feel across all components. It also fixes a key layout bug.

- **Layout Fix:** The root application container now uses `w-full` to ensure it spans the entire viewport width, eliminating any empty space on the right side of the screen.
- **Theme Centralization:**
    - The color scheme and neumorphic shadow styles, originally defined only in the `Sidebar`, have been lifted up to the `Home` component.
    - A `theme` object containing all style variables (`bgColor`, `cardColor`, `neumorph`, etc.) is now created in `Home.jsx` and passed down as a prop to all child components.
- **Component Refactoring:**
    - `Sidebar.jsx`, `ChatInterface.jsx`, and `Summary.jsx` have all been refactored to remove hardcoded or `dark:` prefixed styles.
    - They now exclusively use the variables from the `theme` prop for all their styling, including background colors, text colors, borders, and hover animations. This makes the UI consistent and easier to maintain.