### PR TITLE
Fix: Adjust Sidebar Control Spacing

### DIFF
--- a/Frontend/src/components/Sidebar.jsx
+++ b/Frontend/src/components/Sidebar.jsx
@@ -43,7 +43,7 @@ const Sidebar = ({ theme }) => {
     >
       <div>
         {/* Top controls */}
-        <div className={`flex items-center mb-6 ${collapsed ? 'flex-col gap-4' : 'justify-between'}`}>
+        <div className={`flex items-center my-4 ${collapsed ? 'flex-col gap-4' : 'justify-between'}`}>
           <button
             onClick={() => setCollapsed(!collapsed)}
             className={`text-inherit rounded-full p-2 ${cardColor} hover:${neumorph}`}


### PR DESCRIPTION
This commit adjusts the margins for the top control buttons in the sidebar to provide more vertical spacing and prevent any potential visual overflow, particularly when the sidebar is in its collapsed state. The margin class was changed from `mb-6` to `my-4`.